### PR TITLE
Force UTF-8 character coding

### DIFF
--- a/inkscape_qrcode/qrcode.py
+++ b/inkscape_qrcode/qrcode.py
@@ -22,6 +22,7 @@ Inkscape extension which uses Segno to generate QR Codes.
 """
 from __future__ import absolute_import, unicode_literals
 import inkex
+import locale
 try:
     from ._segno import encoder, utils
 except (ImportError, ValueError):
@@ -73,6 +74,9 @@ class InkscapeQRCode(inkex.Effect):
             micro = True
         boost_error = opts.boost_error == 'true'
         want_background = opts.background == 'true'
+        input_encoding = locale.getdefaultlocale()[1]
+        if input_encoding and input_encoding != 'UTF-8':
+            opts.data = unicode(opts.data, input_encoding).encode('utf8')
         if not micro and opts.symbol_count > 1:
             qrs = encoder.encode_sequence(opts.data, version=version, error=error,
                                           encoding=encoder, boost_error=boost_error,


### PR DESCRIPTION
In the current implementation the output encoding depends on the operating systems encoding, for example in Windows it is cp1252 for me. This causes that the generated QR codes cannot be read properly with a lot scanners.
e.g. generating a QR-Code for '…ÄÖÜ' on my Windows PC (uses cp1252) yields '����' with QR Droid (Zapper engine) and '�ﾖﾜ' QR Droid/Barcode Scanner (ZXing engine).

As UTF-8 seems to be the quasi standard among all scanners I tried I'd simply recommend to force using this encoding. With this encoding all scanners I tried did not had any problems with the encoding.